### PR TITLE
check if .Values.hubconfig.ocpVersion exist before semverCompare

### DIFF
--- a/chart/templates/cluster-permission.yaml
+++ b/chart/templates/cluster-permission.yaml
@@ -93,9 +93,11 @@ spec:
 {{- end }}
       securityContext:
         runAsNonRoot: true
+{{- if .Values.hubconfig.ocpVersion }}
 {{- if semverCompare ">=4.11.0" .Values.hubconfig.ocpVersion }}
         seccompProfile:
           type: RuntimeDefault
+{{- end }}
 {{- end }}
       serviceAccountName: cluster-permission
 {{- with .Values.hubconfig.tolerations }}


### PR DESCRIPTION
Fix the below error when install with chart:
```
Error: INSTALLATION FAILED: template: cluster-permission/templates/cluster-permission.yaml:96:39: executing "cluster-permission/templates/cluster-permission.yaml" at <.Values.hubconfig.ocpVersion>: wrong type for value; expected string; got interface {} 
```