### PR TITLE
Clusterpermission users and groups support

### DIFF
--- a/.github/workflows/go-presubmit.yml
+++ b/.github/workflows/go-presubmit.yml
@@ -110,12 +110,12 @@ jobs:
       - name: setup kind
         uses: engineerd/setup-kind@v0.5.0
         with:
-          version: v0.14.0
+          version: v0.27.0
           name: cluster1
       - name: setup kind
         uses: engineerd/setup-kind@v0.5.0
         with:
-          version: v0.14.0
+          version: v0.27.0
           name: hub
       - name: Load image on the nodes of the cluster
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ Dockerfile.cross
 *.swp
 *.swo
 *~
+.vscode

--- a/api/v1alpha1/clusterpermission_types.go
+++ b/api/v1alpha1/clusterpermission_types.go
@@ -34,6 +34,7 @@ type ClusterPermissionSpec struct {
 
 	// ClusterRoleBinding represents the ClusterRoleBinding that is being created on the managed cluster
 	// +optional
+	// +kubebuilder:validation:XValidation:rule="has(self.subject) || has(self.subjects)",message="Either subject or subjects has to exist in clusterRoleBinding"
 	ClusterRoleBinding *ClusterRoleBinding `json:"clusterRoleBinding,omitempty"`
 
 	// Roles represents roles that are being created on the managed cluster
@@ -42,6 +43,7 @@ type ClusterPermissionSpec struct {
 
 	// RoleBindings represents RoleBindings that are being created on the managed cluster
 	// +optional
+	// +kubebuilder:validation:XValidation:rule="self.all(i, has(i.subject) || has(i.subjects))",message="Either subject or subjects has to exist in every roleBinding"
 	RoleBindings *[]RoleBinding `json:"roleBindings,omitempty"`
 }
 
@@ -56,8 +58,15 @@ type ClusterRole struct {
 type ClusterRoleBinding struct {
 	// Subject contains a reference to the object or user identities a ClusterPermission binding applies to.
 	// Besides the typical subject for a binding, a ManagedServiceAccount can be used as a subject as well.
-	// +required
-	rbacv1.Subject `json:"subject"`
+	// If both subject and subjects exist then only subjects will be used.
+	// +optional
+	Subject rbacv1.Subject `json:"subject"`
+
+	// Subjects contains an array of references to objects or user identities a ClusterPermission binding applies to.
+	// Besides the typical subject for a binding, a ManagedServiceAccount can be used as a subject as well.
+	// If both subject and subjects exist then only subjects will be used.
+	// +optional
+	Subjects []rbacv1.Subject `json:"subjects"`
 
 	// Name of the ClusterRoleBinding if a name different than the ClusterPermission name is used
 	// +optional
@@ -88,8 +97,15 @@ type Role struct {
 type RoleBinding struct {
 	// Subject contains a reference to the object or user identities a ClusterPermission binding applies to.
 	// Besides the typical subject for a binding, a ManagedServiceAccount can be used as a subject as well.
-	// +required
+	// If both subject and subjects exist then only subjects will be used.
+	// +optional
 	rbacv1.Subject `json:"subject"`
+
+	// Subjects contains an array of references to objects or user identities a ClusterPermission binding applies to.
+	// Besides the typical subject for a binding, a ManagedServiceAccount can be used as a subject as well.
+	// If both subject and subjects exist then only subjects will be used.
+	// +optional
+	Subjects []rbacv1.Subject `json:"subjects"`
 
 	// RoleRef contains information that points to the role being used
 	// +required

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -180,6 +180,11 @@ func (in *ClusterRole) DeepCopy() *ClusterRole {
 func (in *ClusterRoleBinding) DeepCopyInto(out *ClusterRoleBinding) {
 	*out = *in
 	out.Subject = in.Subject
+	if in.Subjects != nil {
+		in, out := &in.Subjects, &out.Subjects
+		*out = make([]v1.Subject, len(*in))
+		copy(*out, *in)
+	}
 	if in.RoleRef != nil {
 		in, out := &in.RoleRef, &out.RoleRef
 		*out = new(v1.RoleRef)
@@ -228,6 +233,11 @@ func (in *Role) DeepCopy() *Role {
 func (in *RoleBinding) DeepCopyInto(out *RoleBinding) {
 	*out = *in
 	out.Subject = in.Subject
+	if in.Subjects != nil {
+		in, out := &in.Subjects, &out.Subjects
+		*out = make([]v1.Subject, len(*in))
+		copy(*out, *in)
+	}
 	out.RoleRef = in.RoleRef
 	if in.NamespaceSelector != nil {
 		in, out := &in.NamespaceSelector, &out.NamespaceSelector

--- a/chart/crds/rbac.open-cluster-management.io_clusterpermissions.yaml
+++ b/chart/crds/rbac.open-cluster-management.io_clusterpermissions.yaml
@@ -129,6 +129,7 @@ spec:
                     description: |-
                       Subject contains a reference to the object or user identities a ClusterPermission binding applies to.
                       Besides the typical subject for a binding, a ManagedServiceAccount can be used as a subject as well.
+                      If both subject and subjects exist then only subjects will be used.
                     properties:
                       apiGroup:
                         description: |-
@@ -154,9 +155,45 @@ spec:
                     - name
                     type: object
                     x-kubernetes-map-type: atomic
-                required:
-                - subject
+                  subjects:
+                    description: |-
+                      Subjects contains an array of references to objects or user identities a ClusterPermission binding applies to.
+                      Besides the typical subject for a binding, a ManagedServiceAccount can be used as a subject as well.
+                      If both subject and subjects exist then only subjects will be used.
+                    items:
+                      description: |-
+                        Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,
+                        or a value for non-objects such as user and group names.
+                      properties:
+                        apiGroup:
+                          description: |-
+                            APIGroup holds the API group of the referenced subject.
+                            Defaults to "" for ServiceAccount subjects.
+                            Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
+                          type: string
+                        kind:
+                          description: |-
+                            Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount".
+                            If the Authorizer does not recognized the kind value, the Authorizer should report an error.
+                          type: string
+                        name:
+                          description: Name of the object being referenced.
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty
+                            the Authorizer should report an error.
+                          type: string
+                      required:
+                      - kind
+                      - name
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    type: array
                 type: object
+                x-kubernetes-validations:
+                - message: Either subject or subjects has to exist in clusterRoleBinding
+                  rule: has(self.subject) || has(self.subjects)
               roleBindings:
                 description: RoleBindings represents RoleBindings that are being created
                   on the managed cluster
@@ -241,6 +278,7 @@ spec:
                       description: |-
                         Subject contains a reference to the object or user identities a ClusterPermission binding applies to.
                         Besides the typical subject for a binding, a ManagedServiceAccount can be used as a subject as well.
+                        If both subject and subjects exist then only subjects will be used.
                       properties:
                         apiGroup:
                           description: |-
@@ -266,11 +304,48 @@ spec:
                       - name
                       type: object
                       x-kubernetes-map-type: atomic
+                    subjects:
+                      description: |-
+                        Subjects contains an array of references to objects or user identities a ClusterPermission binding applies to.
+                        Besides the typical subject for a binding, a ManagedServiceAccount can be used as a subject as well.
+                        If both subject and subjects exist then only subjects will be used.
+                      items:
+                        description: |-
+                          Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,
+                          or a value for non-objects such as user and group names.
+                        properties:
+                          apiGroup:
+                            description: |-
+                              APIGroup holds the API group of the referenced subject.
+                              Defaults to "" for ServiceAccount subjects.
+                              Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
+                            type: string
+                          kind:
+                            description: |-
+                              Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount".
+                              If the Authorizer does not recognized the kind value, the Authorizer should report an error.
+                            type: string
+                          name:
+                            description: Name of the object being referenced.
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty
+                              the Authorizer should report an error.
+                            type: string
+                        required:
+                        - kind
+                        - name
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      type: array
                   required:
                   - roleRef
-                  - subject
                   type: object
                 type: array
+                x-kubernetes-validations:
+                - message: Either subject or subjects has to exist in every roleBinding
+                  rule: self.all(i, has(i.subject) || has(i.subjects))
               roles:
                 description: Roles represents roles that are being created on the
                   managed cluster

--- a/config/crds/rbac.open-cluster-management.io_clusterpermissions.yaml
+++ b/config/crds/rbac.open-cluster-management.io_clusterpermissions.yaml
@@ -129,6 +129,7 @@ spec:
                     description: |-
                       Subject contains a reference to the object or user identities a ClusterPermission binding applies to.
                       Besides the typical subject for a binding, a ManagedServiceAccount can be used as a subject as well.
+                      If both subject and subjects exist then only subjects will be used.
                     properties:
                       apiGroup:
                         description: |-
@@ -154,9 +155,45 @@ spec:
                     - name
                     type: object
                     x-kubernetes-map-type: atomic
-                required:
-                - subject
+                  subjects:
+                    description: |-
+                      Subjects contains an array of references to objects or user identities a ClusterPermission binding applies to.
+                      Besides the typical subject for a binding, a ManagedServiceAccount can be used as a subject as well.
+                      If both subject and subjects exist then only subjects will be used.
+                    items:
+                      description: |-
+                        Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,
+                        or a value for non-objects such as user and group names.
+                      properties:
+                        apiGroup:
+                          description: |-
+                            APIGroup holds the API group of the referenced subject.
+                            Defaults to "" for ServiceAccount subjects.
+                            Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
+                          type: string
+                        kind:
+                          description: |-
+                            Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount".
+                            If the Authorizer does not recognized the kind value, the Authorizer should report an error.
+                          type: string
+                        name:
+                          description: Name of the object being referenced.
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty
+                            the Authorizer should report an error.
+                          type: string
+                      required:
+                      - kind
+                      - name
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    type: array
                 type: object
+                x-kubernetes-validations:
+                - message: Either subject or subjects has to exist in clusterRoleBinding
+                  rule: has(self.subject) || has(self.subjects)
               roleBindings:
                 description: RoleBindings represents RoleBindings that are being created
                   on the managed cluster
@@ -241,6 +278,7 @@ spec:
                       description: |-
                         Subject contains a reference to the object or user identities a ClusterPermission binding applies to.
                         Besides the typical subject for a binding, a ManagedServiceAccount can be used as a subject as well.
+                        If both subject and subjects exist then only subjects will be used.
                       properties:
                         apiGroup:
                           description: |-
@@ -266,11 +304,48 @@ spec:
                       - name
                       type: object
                       x-kubernetes-map-type: atomic
+                    subjects:
+                      description: |-
+                        Subjects contains an array of references to objects or user identities a ClusterPermission binding applies to.
+                        Besides the typical subject for a binding, a ManagedServiceAccount can be used as a subject as well.
+                        If both subject and subjects exist then only subjects will be used.
+                      items:
+                        description: |-
+                          Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,
+                          or a value for non-objects such as user and group names.
+                        properties:
+                          apiGroup:
+                            description: |-
+                              APIGroup holds the API group of the referenced subject.
+                              Defaults to "" for ServiceAccount subjects.
+                              Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
+                            type: string
+                          kind:
+                            description: |-
+                              Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount".
+                              If the Authorizer does not recognized the kind value, the Authorizer should report an error.
+                            type: string
+                          name:
+                            description: Name of the object being referenced.
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty
+                              the Authorizer should report an error.
+                            type: string
+                        required:
+                        - kind
+                        - name
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      type: array
                   required:
                   - roleRef
-                  - subject
                   type: object
                 type: array
+                x-kubernetes-validations:
+                - message: Either subject or subjects has to exist in every roleBinding
+                  rule: self.all(i, has(i.subject) || has(i.subjects))
               roles:
                 description: Roles represents roles that are being created on the
                   managed cluster

--- a/config/samples/clusterpermission_clusterrolebinding_error.yaml
+++ b/config/samples/clusterpermission_clusterrolebinding_error.yaml
@@ -1,0 +1,11 @@
+# This sample is for testing only, does not work
+apiVersion: rbac.open-cluster-management.io/v1alpha1
+kind: ClusterPermission
+metadata:
+  name: clusterpermission-clusterrolebinding-error
+spec:
+  clusterRoleBinding:
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: argocd-application-controller-3

--- a/config/samples/clusterpermission_rolebinding_error.yaml
+++ b/config/samples/clusterpermission_rolebinding_error.yaml
@@ -1,0 +1,12 @@
+# This sample is for testing only, does not work
+apiVersion: rbac.open-cluster-management.io/v1alpha1
+kind: ClusterPermission
+metadata:
+  name: clusterpermission-rolebinding-error
+spec:
+  roleBindings:
+    - namespace: default
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: argocd-application-controller-users-1

--- a/config/samples/clusterpermission_users_groups.yaml
+++ b/config/samples/clusterpermission_users_groups.yaml
@@ -1,0 +1,44 @@
+apiVersion: rbac.open-cluster-management.io/v1alpha1
+kind: ClusterPermission
+metadata:
+  name: clusterpermission-users-groups
+spec:
+  roleBindings:
+    - namespace: default
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: argocd-application-controller-users-1
+      subjects:
+      - namespace: openshift-gitops
+        kind: ServiceAccount
+        name: sa-sample-existing
+      - apiGroup: rbac.authorization.k8s.io
+        kind: User
+        name: argo-users1
+    - name: kubevirt-rb-cluster1-users1
+      namespace: kube-system
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: argocd-application-controller-users-2
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: User
+        name: users1
+      - apiGroup: rbac.authorization.k8s.io
+        kind: User
+        name: users2
+  clusterRoleBinding:
+      name: crb-cluster1-argo-app-con-groups
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: argocd-application-controller-3
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: groups1
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: groups2

--- a/controllers/clusterpermission_controller.go
+++ b/controllers/clusterpermission_controller.go
@@ -208,12 +208,11 @@ func (r *ClusterPermissionReconciler) validateSubject(ctx context.Context, subje
 }
 
 func getSubjects(subject rbacv1.Subject, subjects []rbacv1.Subject) []rbacv1.Subject {
-	crbSubjects := []rbacv1.Subject{}
 	if len(subjects) > 0 {
 		return subjects
 	} else {
 		// should be safe since one of them has to exist
-		return append(crbSubjects, subject)
+		return []rbacv1.Subject{subject}
 	}
 }
 

--- a/controllers/clusterpermission_controller.go
+++ b/controllers/clusterpermission_controller.go
@@ -120,7 +120,7 @@ func (r *ClusterPermissionReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	clusterRole, clusterRoleBinding, roles, roleBindings, err := r.generateManifestWorkPayload(
 		ctx, &clusterPermission)
 	if err != nil {
-		log.Info("failed to generate payload")
+		log.Error(err, "failed to generate payload")
 
 		errStatus := r.updateStatus(ctx, &clusterPermission, &metav1.Condition{
 			Type:    cpv1alpha1.ConditionTypeAppliedRBACManifestWork,

--- a/controllers/clusterpermission_controller_test.go
+++ b/controllers/clusterpermission_controller_test.go
@@ -94,6 +94,7 @@ var _ = Describe("ClusterPermission controller", func() {
 						}},
 					}},
 					ClusterRoleBinding: &cpv1alpha1.ClusterRoleBinding{
+						Subjects: []rbacv1.Subject{},
 						Subject: rbacv1.Subject{
 							Kind:      "ServiceAccount",
 							Name:      "klusterlet-work-sa",
@@ -104,6 +105,7 @@ var _ = Describe("ClusterPermission controller", func() {
 						{
 							Namespace: "default",
 							RoleRef:   cpv1alpha1.RoleRef{Kind: "ClusterRole"},
+							Subjects:  []rbacv1.Subject{},
 							Subject: rbacv1.Subject{
 								Kind:      "ServiceAccount",
 								Name:      "klusterlet-work-sa",
@@ -412,6 +414,7 @@ var _ = Describe("ClusterPermission controller", func() {
 						}},
 					},
 					ClusterRoleBinding: &cpv1alpha1.ClusterRoleBinding{
+						Subjects: []rbacv1.Subject{},
 						Subject: rbacv1.Subject{
 							APIGroup: "authentication.open-cluster-management.io",
 							Kind:     "ManagedServiceAccount",

--- a/controllers/clusterpermission_controller_test.go
+++ b/controllers/clusterpermission_controller_test.go
@@ -200,6 +200,7 @@ var _ = Describe("ClusterPermission controller", func() {
 						}},
 					}},
 					ClusterRoleBinding: &cpv1alpha1.ClusterRoleBinding{
+						Subjects: []rbacv1.Subject{},
 						Subject: rbacv1.Subject{
 							APIGroup: "authentication.open-cluster-management.io",
 							Kind:     "ManagedServiceAccount",
@@ -210,6 +211,7 @@ var _ = Describe("ClusterPermission controller", func() {
 						{
 							Namespace: "default",
 							RoleRef:   cpv1alpha1.RoleRef{Kind: "ClusterRole"},
+							Subjects:  []rbacv1.Subject{},
 							Subject: rbacv1.Subject{
 								APIGroup: "authentication.open-cluster-management.io",
 								Kind:     "ManagedServiceAccount",
@@ -256,6 +258,7 @@ var _ = Describe("ClusterPermission controller", func() {
 						{
 							NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"a": "b"}},
 							RoleRef:           cpv1alpha1.RoleRef{Kind: "ClusterRole"},
+							Subjects:          []rbacv1.Subject{},
 							Subject: rbacv1.Subject{
 								APIGroup: "authentication.open-cluster-management.io",
 								Kind:     "ManagedServiceAccount",
@@ -303,6 +306,7 @@ var _ = Describe("ClusterPermission controller", func() {
 								Kind:     "ClusterRole",
 								Name:     "argocd-application-controller-1",
 							},
+							Subjects: []rbacv1.Subject{},
 							Subject: rbacv1.Subject{
 								Namespace: "openshift-gitops",
 								Kind:      "ServiceAccount",
@@ -317,6 +321,7 @@ var _ = Describe("ClusterPermission controller", func() {
 								Kind:     "Role",
 								Name:     "argocd-application-controller-2",
 							},
+							Subjects: []rbacv1.Subject{},
 							Subject: rbacv1.Subject{
 								APIGroup: "rbac.authorization.k8s.io",
 								Kind:     "User",
@@ -330,6 +335,7 @@ var _ = Describe("ClusterPermission controller", func() {
 								Kind:     "Role",
 								Name:     "argocd-application-controller-2",
 							},
+							Subjects: []rbacv1.Subject{},
 							Subject: rbacv1.Subject{
 								APIGroup: "rbac.authorization.k8s.io",
 								Kind:     "User",
@@ -344,6 +350,7 @@ var _ = Describe("ClusterPermission controller", func() {
 							Kind:     "ClusterRole",
 							Name:     "argocd-application-controller-3",
 						},
+						Subjects: []rbacv1.Subject{},
 						Subject: rbacv1.Subject{
 							APIGroup: "rbac.authorization.k8s.io",
 							Kind:     "Group",
@@ -462,6 +469,7 @@ var _ = Describe("ClusterPermission controller", func() {
 					},
 					RoleBindings: &[]cpv1alpha1.RoleBinding{
 						{
+							Subjects: []rbacv1.Subject{},
 							Subject: rbacv1.Subject{
 								APIGroup: "authentication.open-cluster-management.io",
 								Kind:     "ManagedServiceAccount",
@@ -547,6 +555,7 @@ var _ = Describe("ClusterPermission controller", func() {
 								Kind: "ClusterRole",
 								Name: "argocd-application-controller-1",
 							},
+							Subjects: []rbacv1.Subject{},
 							Subject: rbacv1.Subject{
 								Namespace: "openshift-gitops",
 								Kind:      "ServiceAccount",
@@ -574,6 +583,7 @@ var _ = Describe("ClusterPermission controller", func() {
 								APIGroup: "rbac.authorization.k8s.io",
 								Kind:     "ClusterRole",
 							},
+							Subjects: []rbacv1.Subject{},
 							Subject: rbacv1.Subject{
 								Namespace: "openshift-gitops",
 								Kind:      "ServiceAccount",

--- a/controllers/clusterpermission_controller_test.go
+++ b/controllers/clusterpermission_controller_test.go
@@ -700,13 +700,17 @@ func TestGenerateSubject(t *testing.T) {
 				Scheme: testscheme,
 			}
 
-			subject, err := cpr.generateSubject(context.TODO(), getSubjects(c.subject, c.subjects), c.clusterNamespace)
+			subjects, err := cpr.generateSubject(context.TODO(), getSubjects(c.subject, c.subjects), c.clusterNamespace)
 			if err != nil {
 				t.Errorf("generateSubject() error = %v", err)
 			}
 
-			if !reflect.DeepEqual(subject, c.expectedSubject) {
-				t.Errorf("expected subject %v, got %v", c.expectedSubject, subject)
+			if len(subjects) == 0 {
+				t.Errorf("generateSubject() return zero subjects")
+			}
+
+			if !reflect.DeepEqual(subjects[0], c.expectedSubject) {
+				t.Errorf("expected subject %v, got %v", c.expectedSubject, subjects[0])
 			}
 		})
 	}

--- a/e2e/run_e2e.sh
+++ b/e2e/run_e2e.sh
@@ -89,3 +89,39 @@ else
     echo "kubevirt-rb-cluster1-users1 rolebinding not found"
     exit 1
 fi
+
+if kubectl -n kube-system get rolebinding kubevirt-rb-cluster1-users1 -o yaml | grep users1: then
+    echo "kubevirt-rb-cluster1-users1 users1 found"
+else
+    echo "kubevirt-rb-cluster1-users1 users1 not found"
+    exit 1
+fi
+
+if kubectl -n kube-system get rolebinding kubevirt-rb-cluster1-users1 -o yaml | grep users2: then
+    echo "kubevirt-rb-cluster1-users1 users2 found"
+else
+    echo "kubevirt-rb-cluster1-users1 users2 not found"
+    exit 1
+fi
+
+echo "TEST ClusterPermission ClusterRoleBinding with no subject or subjects"
+crb_err_msg="The ClusterPermission \"clusterpermission-clusterrolebinding-error\" is invalid: spec.clusterRoleBinding: Invalid value: \"object\": Either subject or subjects has to exist in clusterRoleBinding"
+crb_error=$(kubectl apply -f config/samples/clusterpermission_clusterrolebinding_error.yaml -n cluster1 2>&1)
+
+if [ "$crb_error" == "$crb_err_msg" ]; then
+    echo "ClusterRoleBinding error found"
+else
+    echo "ClusterRoleBinding error not found"
+    exit 1
+fi
+
+echo "TEST ClusterPermission RoleBinding with no subject or subjects"
+rb_err_msg="The ClusterPermission "clusterpermission-rolebinding-error" is invalid: spec.roleBindings: Invalid value: "array": Either subject or subjects has to exist in every roleBinding"
+rb_error=$(kubectl apply -f config/samples/clusterpermission_rolebinding_error.yaml -n cluster1 2>&1)
+
+if [ "$rb_error" == "$rb_error" ]; then
+    echo "RoleBinding error found"
+else
+    echo "RoleBinding error not found"
+    exit 1
+fi

--- a/e2e/run_e2e.sh
+++ b/e2e/run_e2e.sh
@@ -126,6 +126,8 @@ echo "TEST ClusterPermission ClusterRoleBinding with no subject or subjects"
 crb_err_msg="The ClusterPermission \"clusterpermission-clusterrolebinding-error\" is invalid: spec.clusterRoleBinding: Invalid value: \"object\": Either subject or subjects has to exist in clusterRoleBinding"
 crb_error=$(kubectl apply -f config/samples/clusterpermission_clusterrolebinding_error.yaml -n cluster1 2>&1)
 
+echo $crb_error
+
 if [ "$crb_error" == "$crb_err_msg" ]; then
     echo "ClusterRoleBinding error found"
 else
@@ -136,6 +138,8 @@ fi
 echo "TEST ClusterPermission RoleBinding with no subject or subjects"
 rb_err_msg="The ClusterPermission "clusterpermission-rolebinding-error" is invalid: spec.roleBindings: Invalid value: "array": Either subject or subjects has to exist in every roleBinding"
 rb_error=$(kubectl apply -f config/samples/clusterpermission_rolebinding_error.yaml -n cluster1 2>&1)
+
+echo $rb_error
 
 if [ "$rb_error" == "$rb_error" ]; then
     echo "RoleBinding error found"

--- a/e2e/run_e2e.sh
+++ b/e2e/run_e2e.sh
@@ -73,7 +73,7 @@ fi
 
 echo "TEST ClusterPermission with users and groups"
 kubectl config use-context kind-hub
-kubectl apply -f config/samples/clusterpermission-users-groups.yaml -n cluster1
+kubectl apply -f config/samples/clusterpermission_users_groups.yaml -n cluster1
 sleep 10
 work_kubectl_command=$(kubectl -n cluster1 get clusterpermission clusterpermission-users-groups -o yaml | grep kubectl | grep ManifestWork)
 if $work_kubectl_command; then

--- a/e2e/run_e2e.sh
+++ b/e2e/run_e2e.sh
@@ -70,3 +70,22 @@ else
     echo "default-rb-cluster1 rolebinding not found"
     exit 1
 fi
+
+echo "TEST ClusterPermission with users and groups"
+kubectl config use-context kind-hub
+kubectl apply -f config/samples/clusterpermission-users-groups.yaml -n cluster1
+sleep 10
+work_kubectl_command=$(kubectl -n cluster1 get clusterpermission clusterpermission-users-groups -o yaml | grep kubectl | grep ManifestWork)
+if $work_kubectl_command; then
+    echo "ManifestWork found"
+else
+    echo "ManifestWork not found"
+    exit 1
+fi
+
+if kubectl -n default get rolebinding kubevirt-rb-cluster1-users1; then
+    echo "kubevirt-rb-cluster1-users1 rolebinding found"
+else
+    echo "kubevirt-rb-cluster1-users1 rolebinding not found"
+    exit 1
+fi

--- a/e2e/run_e2e.sh
+++ b/e2e/run_e2e.sh
@@ -18,7 +18,7 @@ fi
 echo "TEST ClusterPermission"
 kubectl config use-context kind-hub
 kubectl apply -f config/samples/rbac.open-cluster-management.io_v1alpha1_clusterpermission.yaml -n cluster1
-sleep 10
+sleep 30
 work_kubectl_command=$(kubectl -n cluster1 get clusterpermission -o yaml | grep kubectl | grep ManifestWork)
 if $work_kubectl_command; then
     echo "ManifestWork found"

--- a/e2e/run_e2e.sh
+++ b/e2e/run_e2e.sh
@@ -27,6 +27,24 @@ else
     exit 1
 fi
 
+echo
+echo
+echo "==========ClusterPermission=========="
+kubectl -n cluster1 get clusterpermission -o yaml
+echo
+echo
+echo
+echo "==========ManifestWork=========="
+kubectl -n cluster1 get manifestwork -o yaml
+echo
+echo
+echo
+echo "==========Logging=========="
+kubectl logs -n open-cluster-management -l name=cluster-permission
+echo
+echo
+echo
+
 if kubectl -n default get role clusterpermission-sample; then
     echo "clusterpermission-sample role found"
 else

--- a/e2e/run_e2e.sh
+++ b/e2e/run_e2e.sh
@@ -83,7 +83,7 @@ else
     exit 1
 fi
 
-if kubectl -n default get rolebinding kubevirt-rb-cluster1-users1; then
+if kubectl -n kube-system get rolebinding kubevirt-rb-cluster1-users1; then
     echo "kubevirt-rb-cluster1-users1 rolebinding found"
 else
     echo "kubevirt-rb-cluster1-users1 rolebinding not found"

--- a/e2e/run_e2e.sh
+++ b/e2e/run_e2e.sh
@@ -55,7 +55,7 @@ fi
 echo "TEST ClusterPermission with existing roles"
 kubectl config use-context kind-hub
 kubectl apply -f config/samples/clusterpermission_existing_roles.yaml -n cluster1
-sleep 10
+sleep 30
 work_kubectl_command=$(kubectl -n cluster1 get clusterpermission clusterpermission-existing-role-sample -o yaml | grep kubectl | grep ManifestWork)
 if $work_kubectl_command; then
     echo "ManifestWork found"
@@ -74,7 +74,7 @@ fi
 echo "TEST ClusterPermission with users and groups"
 kubectl config use-context kind-hub
 kubectl apply -f config/samples/clusterpermission_users_groups.yaml -n cluster1
-sleep 10
+sleep 30
 work_kubectl_command=$(kubectl -n cluster1 get clusterpermission clusterpermission-users-groups -o yaml | grep kubectl | grep ManifestWork)
 if $work_kubectl_command; then
     echo "ManifestWork found"

--- a/e2e/run_e2e.sh
+++ b/e2e/run_e2e.sh
@@ -108,14 +108,14 @@ else
     exit 1
 fi
 
-if kubectl -n kube-system get rolebinding kubevirt-rb-cluster1-users1 -o yaml | grep users1: then
+if kubectl -n kube-system get rolebinding kubevirt-rb-cluster1-users1 -o yaml | grep users1; then
     echo "kubevirt-rb-cluster1-users1 users1 found"
 else
     echo "kubevirt-rb-cluster1-users1 users1 not found"
     exit 1
 fi
 
-if kubectl -n kube-system get rolebinding kubevirt-rb-cluster1-users1 -o yaml | grep users2: then
+if kubectl -n kube-system get rolebinding kubevirt-rb-cluster1-users1 -o yaml | grep users2; then
     echo "kubevirt-rb-cluster1-users1 users2 found"
 else
     echo "kubevirt-rb-cluster1-users1 users2 not found"


### PR DESCRIPTION
- Add support for binding to multiple users and groups.
- Kept the subject field but made it optional for backwards compatibility.
- Added new `subjects` field(also optional for backwards compatibility) to allow adding multiple users and groups.
- Error if either `subject` or `subjects` are missing.
- `subjects` will override `subject` if both fields exist.

Example:

```
apiVersion: rbac.open-cluster-management.io/v1alpha1
kind: ClusterPermission
metadata:
  name: clusterpermission-users-groups
spec:
  roleBindings:
    - namespace: default
      roleRef:
        apiGroup: rbac.authorization.k8s.io
        kind: ClusterRole
        name: argocd-application-controller-users-1
      subjects:
      - namespace: openshift-gitops
        kind: ServiceAccount
        name: sa-sample-existing
      - apiGroup: rbac.authorization.k8s.io
        kind: User
        name: argo-users1
```