### PR TITLE
Fix performance issue in large scale envs

### DIFF
--- a/controllers/clusterpermission_controller.go
+++ b/controllers/clusterpermission_controller.go
@@ -60,7 +60,6 @@ type ClusterPermissionReconciler struct {
 func (r *ClusterPermissionReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&cpv1alpha1.ClusterPermission{}).
-		Owns(&workv1.ManifestWork{}).
 		Watches(&addonv1alpha1.ManagedClusterAddOn{},
 			r.managedClusterAddOnEventHandler(),
 			builder.WithPredicates(predicate.Funcs{


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-24032

- Remove Owns function call as this was caching too many ManifestWork events

Now the memory usage is
<img width="814" height="634" alt="image" src="https://github.com/user-attachments/assets/ca3d382a-4dd1-41b6-b740-fa212d1a5f37" />

Probably due to the ManageClusterAddon watch that was added. There is ~21391 ManageClusterAddons on this cluster.