### PR TITLE
docs: add CLAUDE.md and AGENTS.md as symlinks to README.md

### DIFF
--- a/.github/workflows/go-postsubmit.yml
+++ b/.github/workflows/go-postsubmit.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'CHANGELOG/**'
+      - 'LICENSE'
   workflow_dispatch: {}
 
 env:

--- a/.github/workflows/go-presubmit.yml
+++ b/.github/workflows/go-presubmit.yml
@@ -5,6 +5,11 @@ on:
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'CHANGELOG/**'
+      - 'LICENSE'
 
 env:
   # Common versions

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+README.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+README.md


### PR DESCRIPTION
## Summary

- Add `CLAUDE.md` and `AGENTS.md` as symlinks to `README.md` for AI coding tool discovery (Claude Code, Codex, etc.)
- Add `paths-ignore` to `go-presubmit.yml` and `go-postsubmit.yml` so build/test/e2e/image jobs are skipped when only documentation files are changed (`.md`, `docs/`, `CHANGELOG/`, `LICENSE`)

## Details

**Symlinks:**
- `README.md` remains the single source of truth
- `CLAUDE.md -> README.md` (Claude Code)
- `AGENTS.md -> README.md` (Codex/other agents)

**CI paths-ignore covers:**
- `**.md` — all markdown files
- `docs/**` — documentation directory
- `CHANGELOG/**` — changelog files
- `LICENSE` — license file

DCO check, release, and chart-upload workflows are not affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)